### PR TITLE
Update changelog and documentation for Vagrant user management enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.0] - 2026-03-13
+### Added
+- Added `VM_CREATE_USER` to the Vagrant lab configuration so user creation, password SSH setup, and sudo provisioning can be enabled or skipped for fresh base-box testing.
+
+### Changed
+- Hardened the Vagrant provisioning script by escaping shell values before creating users or setting passwords.
+- Increased Vagrant SSH startup tolerance with a longer boot timeout and explicit SSH connect timeout.
+
+### Documentation
+- Updated the Vagrant lab guide to explain when `VM_CREATE_USER` should be used and when a VM must be recreated to return to the base box state.
+- Expanded the Vagrant README with clearer network design, access patterns, boot-time SSH behavior, and recommended workflow for Ansible-focused lab usage.
+
 ## [1.3.0] - 2026-02-27
 ### Changed
 - Refactored Docker setup: reorganized directory structure, updated .gitignore, enhanced README, and improved gen_compose.py for secure and best-practice .env and secret management ([#5](https://github.com/tatbyte/infra-lab/issues/5)).

--- a/docs/01-configure-vagrant-lab.md
+++ b/docs/01-configure-vagrant-lab.md
@@ -27,9 +27,15 @@ Edit `.env` to define:
   - VM_BOX: Vagrant box name (e.g., generic/ubuntu2204)
   - VM_MEMORY: RAM allocated to each VM (in MB, e.g., 2048)
   - VM_CPUS: Number of CPUs allocated to each VM (e.g., 2)
-  - VM_USER: Username to create in each VM (e.g., admin)
-  - VM_PASS: Password for the created user (e.g., admin)
+  - VM_USER: Username to manage in each VM when `VM_CREATE_USER=true` (e.g., `admin` or `vagrant`)
+  - VM_CREATE_USER: Set to `true` to manage `VM_USER` with password SSH and sudo, or `false` to leave the base box unchanged
+  - VM_PASS: Password applied to `VM_USER` when `VM_CREATE_USER=true` (e.g., `admin` or `vagrant`)
   - BRIDGE_IF: Host network interface to bridge for VM LAN access (e.g., eth0)
+
+Supported user modes:
+- Original Vagrant user: `VM_CREATE_USER=false`
+- Vagrant user with password SSH: `VM_CREATE_USER=true`, `VM_USER=vagrant`, `VM_PASS=vagrant`
+- Fully new user: `VM_CREATE_USER=true`, `VM_USER=admin`, `VM_PASS=admin`
 
 ### b. Check Network Interface
 - Ensure `BRIDGE_IF` matches your host's LAN interface.
@@ -44,6 +50,10 @@ Edit `.env` to define:
   vagrant up
   ```
 - VMs will be provisioned with static IPs and bridged networking.
+- To keep a fresh VM on the base box defaults, set `VM_CREATE_USER=false`.
+- To keep the original Vagrant account but add password-based SSH on the LAN IP, use `VM_CREATE_USER=true`, `VM_USER=vagrant`, and `VM_PASS=vagrant`.
+- To use a separate lab account, choose your own `VM_USER` and `VM_PASS` with `VM_CREATE_USER=true`.
+- If a VM was already created in a different mode, run `vagrant destroy -f` and `vagrant up` to rebuild it with the new user mode.
 
 ---
 
@@ -58,11 +68,17 @@ Edit `.env` to define:
   ```sh
   ping 192.168.0.101
   ```
-- SSH into the VM:
+- SSH into the VM with the user for your selected mode:
   ```sh
   ssh admin@192.168.0.101
   # Password: admin (or as set in .env)
   ```
+- If you kept the original Vagrant account with password SSH enabled:
+  ```sh
+  ssh vagrant@192.168.0.101
+  # Password: vagrant (or as set in .env)
+  ```
+- If you left the base box unchanged with `VM_CREATE_USER=false`, use `vagrant ssh node1` or the default key-based Vagrant access for that box.
 
 ---
 
@@ -71,7 +87,7 @@ Edit `.env` to define:
 
 You can SSH directly from the host to any VM:
   ```sh
-  ssh tatbyte@192.168.0.101
+  ssh admin@192.168.0.101
   ```
 
 ### Configure SSH Access Without Vagrant
@@ -87,6 +103,11 @@ If you want passwordless SSH access from the host (without using `vagrant ssh`):
   ssh-copy-id admin@192.168.0.101
   ssh-copy-id admin@192.168.0.102
   # Enter the password as set in .env (e.g., admin)
+  ```
+  Or, if you are using the managed Vagrant account:
+  ```sh
+  ssh-copy-id vagrant@192.168.0.101
+  ssh-copy-id vagrant@192.168.0.102
   ```
 
 3. Now you can SSH without a password:
@@ -117,6 +138,6 @@ Or use Vagrant's built-in SSH:
 1. Install dependencies and clone the project.
 2. Configure `.env` for your network and VM needs.
 3. Launch the lab with `vagrant up`.
-4. Access VMs from other PCs or the host using SSH.
+4. Access VMs from other PCs or the host using the user mode you selected.
 
 For advanced networking or persistent routes, see the main documentation.

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -2,17 +2,100 @@
 
 ## Purpose
 
-This directory contains configuration files for spinning up multiple virtual machines (VMs) using Vagrant and libvirt. The primary goal is to create a reproducible lab environment for testing Ansible automation across several hosts.
+This directory contains configuration files for spinning up multiple virtual machines (VMs) using Vagrant and libvirt.
+
+The primary goal is to create a reproducible lab environment for testing Ansible automation across several hosts in a way that feels closer to real infrastructure.
+
+This lab is intentionally designed to provide:
+
+- a **Vagrant/libvirt management network** for VM lifecycle and built-in Vagrant communication
+- a **LAN-facing bridged network** so each VM has its own reachable IP for SSH, Ansible, Docker, reverse proxy testing, and multi-host lab scenarios
+
+---
 
 ## What the Code Does
 
-- Uses a `.env` file to define VM settings (box, memory, CPUs, user, password, network interface, and hostname-to-IP mapping).
+- Uses a `.env` file to define VM settings such as:
+  - box
+  - memory
+  - CPUs
+  - user
+  - whether to manage that user
+  - password
+  - bridge interface
+  - hostname-to-IP mapping
+
 - The `Vagrantfile` reads these settings and provisions VMs with:
-  - Static LAN IPs for each VM
-  - Custom user creation and SSH password setup
-  - Bridged networking for direct LAN access
-  - Resource allocation (RAM, CPU)
-  - Automated SSH configuration for Ansible compatibility
+  - static LAN IPs for each VM
+  - optional user management with password/sudo setup
+  - bridged networking for direct LAN access
+  - resource allocation (RAM and CPU)
+  - automated SSH configuration for Ansible compatibility
+
+- Keeps the default libvirt management path so Vagrant can still manage the VM lifecycle.
+
+---
+
+## Network Design
+
+This lab uses **two different network paths** on purpose.
+
+### 1. Vagrant/libvirt management network
+
+This network is used internally by Vagrant for:
+
+- detecting the VM IP
+- waiting for SSH during boot
+- `vagrant ssh`
+- machine lifecycle operations
+
+Example IP range:
+
+- `192.168.121.x`
+
+Typical access:
+
+- `vagrant@192.168.121.x`
+
+### 2. Bridged LAN network
+
+This network is used for normal lab access and realistic host testing.
+
+It gives each VM its own IP on the LAN so it can be used like a real host for:
+
+- SSH from the host
+- SSH from other machines
+- Ansible inventory testing
+- Docker and container testing
+- reverse proxy testing
+- multi-host communication
+
+Example IP:
+
+- `192.168.0.101`
+
+Typical access:
+
+- `admin@192.168.0.101`
+
+---
+
+## Why This Lab Uses a LAN IP Per Host
+
+The LAN IP is kept on purpose because this lab is used for more than just `vagrant ssh`.
+
+It allows each VM to behave like a real machine on the network, which is useful for:
+
+- testing Ansible against realistic target IPs
+- testing Docker containers that expose ports on each host
+- testing hostname/IP-based services
+- validating reverse proxy behavior
+- accessing VMs over SSH from another machine
+- simulating a small real network
+
+This is why the bridged/static IP design should be kept.
+
+---
 
 ## Typical Use Cases
 
@@ -20,6 +103,9 @@ This directory contains configuration files for spinning up multiple virtual mac
 - Simulating a small network for development or CI
 - Experimenting with network configurations and automation
 - Learning and practicing infrastructure-as-code
+- Testing Docker or other services on separate hosts with real LAN IPs
+
+---
 
 ## What You Can Do With These VMs
 
@@ -27,28 +113,263 @@ This directory contains configuration files for spinning up multiple virtual mac
 - Run Ansible playbooks targeting multiple hosts
 - Install and test software as you would on real machines
 - Experiment with networking, user management, and system configuration
+- Test Docker containers and service exposure on distinct VM IPs
 
-## Limitations of Virtual Machines
+---
 
-- Performance is lower than physical hardware (especially for CPU and disk-intensive tasks)
-- Access to hardware features (e.g., GPU, USB devices) is limited or unavailable
-- Network behavior may differ from real-world setups (e.g., latency, broadcast)
-- Not suitable for production workloads or high-availability testing
-- Some advanced features (like nested virtualization) may require extra configuration or may not work
+## How Access Works
+
+In practice, the same VM may be reachable in two ways:
+
+- through the libvirt management network for Vagrant
+- through the bridged LAN IP for normal operator access
+
+The actual LAN login depends on which user mode you selected in `.env`.
+
+Examples:
+
+    vagrant@192.168.121.x
+    admin@192.168.0.101
+
+Recommended usage:
+
+- use **Vagrant** for VM lifecycle
+- use the **LAN IP** for your real SSH work and Ansible testing
+
+Example:
+
+    ssh admin@192.168.0.101
+
+---
+
+## User Modes
+
+The Vagrant lab supports three practical user modes.
+
+### 1. Original Vagrant user
+
+Use:
+
+    VM_CREATE_USER=false
+
+Behavior:
+
+- leaves the base box user setup unchanged
+- keeps the default Vagrant account and key-based access path
+- best when you want the box exactly as provided upstream
+
+Typical access:
+
+    vagrant ssh node1
+
+### 2. Original Vagrant user plus password SSH
+
+Use:
+
+    VM_CREATE_USER=true
+    VM_USER=vagrant
+    VM_PASS=vagrant
+
+Behavior:
+
+- keeps the existing `vagrant` user
+- updates that user password
+- grants sudo through the managed provisioning block
+- enables password SSH for LAN access
+
+Typical access:
+
+    ssh vagrant@192.168.0.101
+
+### 3. Fully new lab user
+
+Use:
+
+    VM_CREATE_USER=true
+    VM_USER=admin
+    VM_PASS=admin
+
+Behavior:
+
+- creates a separate lab user when it does not already exist
+- sets that user password and sudo access
+- enables password SSH for LAN access
+
+Typical access:
+
+    ssh admin@192.168.0.101
+
+If you switch modes after a VM was already created, rebuild it:
+
+    vagrant destroy -f
+    vagrant up
+
+---
+
+## SSH / Boot Issue Encountered
+
+A boot-time issue was observed where:
+
+- `vagrant up` showed:
+  - `Host unreachable`
+  - `Connection refused`
+- but the VM was actually booting and became reachable later with manual SSH
+
+This happened even though:
+
+- the `vagrant` user still existed
+- the Vagrant private key matched the guest `authorized_keys`
+- SSH configuration was valid
+- the firewall allowed SSH
+- manual SSH worked after boot
+
+So the issue was **not** caused by a broken SSH key, deleted user, or invalid sshd configuration.
+
+---
+
+## Root Cause
+
+The root cause was related to **boot timing with two network interfaces**.
+
+The VM had:
+
+- one NIC for libvirt/Vagrant management
+- one NIC for bridged LAN access
+
+During boot, `systemd-networkd-wait-online.service` delayed the system while waiting for the network to be considered fully online.
+
+That delay caused a problem:
+
+- Vagrant started trying SSH on the management IP early
+- port 22 was not ready yet
+- Vagrant saw repeated `Connection refused`
+
+So the machine itself was fine, but Vagrant reached it before SSH was available.
+
+---
+
+## Current Mitigation
+
+The current Vagrant configuration increases SSH startup tolerance:
+
+- `config.vm.boot_timeout = 300`
+- `config.ssh.connect_timeout = 30`
+
+Why this helps:
+
+- Vagrant waits longer for the guest to finish booting
+- transient early boot `Connection refused` failures are less likely to abort `vagrant up`
+
+---
+
+## Why This Fix Is Acceptable Here
+
+This lab is built for:
+
+- fast VM creation
+- SSH access
+- Ansible testing
+- Docker and service testing
+
+It does **not** need to block boot waiting for every network interface to be declared fully online before the system continues.
+
+For this use case, allowing a longer SSH startup window improves reliability without changing the base box boot services.
+
+---
+
+## Relationship With Ansible
+
+This Vagrant lab is intended to support Ansible development and testing.
+
+The general workflow is:
+
+1. Use Vagrant to create the VM
+2. Use the LAN IP to reach the VM like a real host
+3. Test Ansible roles and playbooks safely before using them elsewhere
+
+This makes the lab useful for validating things such as:
+
+- bootstrap users
+- SSH access
+- base roles
+- Docker hosts
+- service exposure
+- multi-host automation behavior
+
+The extra network interface is part of that realism and should not be treated as accidental.
+
+---
+
+## Recommended Workflow
+
+1. Copy `template.env` to `.env` and adjust settings as needed
+2. Run `vagrant up` to start the lab
+3. Use the LAN IP to SSH into the VM with the user mode you selected
+4. Test Ansible playbooks, roles, Docker, or other tooling
+
+Examples:
+
+    vagrant up
+    ssh admin@192.168.0.101
+
+Use `vagrant ssh <hostname>` when you keep the original base-box user mode. For password-managed modes, the LAN IP is usually the preferred path.
+
+---
 
 ## Extending the Lab
 
-- Add more hosts by updating the `VM_MAPPING` in `.env`
+- Add more hosts by updating `VM_MAPPING` in `.env`
 - Change the base box or resources for different OS or performance
 - Customize provisioning scripts for more complex setups
-- Integrate with other tools (e.g., Docker, Kubernetes) for hybrid testing
+- Integrate with other tools such as Docker or Kubernetes for hybrid testing
 
-## Getting Started
+---
 
-1. Copy `template.env` to `.env` and adjust settings as needed.
-2. Run `vagrant up` to start the lab.
-3. Use `vagrant ssh <hostname>` or SSH directly to each VM.
-4. Test your Ansible playbooks or other automation tools.
+## Limitations of Virtual Machines
+
+- Performance is lower than physical hardware, especially for CPU and disk-intensive tasks
+- Access to hardware features such as GPU or USB devices is limited or unavailable
+- Network behavior may differ from real-world production environments
+- Not suitable for production workloads or high-availability testing
+- Some advanced features such as nested virtualization may require extra configuration or may not work
+
+---
+
+## Helpful Commands
+
+### Check Vagrant SSH config
+
+    vagrant ssh-config
+
+### Check guest IPs
+
+    ip -br addr
+    ip route
+
+### Check SSH readiness in the guest
+
+    sudo journalctl -b -u ssh --no-pager
+    sudo ss -tlnp | grep ':22'
+
+### Check boot delays
+
+    systemd-analyze
+    systemd-analyze blame | head -30
+
+---
+
+## Summary
+
+This directory provides a reproducible Vagrant/libvirt VM lab for realistic Ansible and Docker testing.
+
+The setup intentionally uses:
+
+- a libvirt management NIC for Vagrant
+- a bridged LAN NIC for realistic per-host access
+
+The boot-time SSH issue was caused by delayed network readiness, not by broken Ansible logic or invalid SSH configuration.
+
+The current mitigation is a longer Vagrant boot and SSH timeout, while the per-host LAN IP design remains in place for testing.
 
 ---
 

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,5 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+require "shellwords"
+
 ENV_FILE = ".env"
 abort(".env file not found") unless File.exist?(ENV_FILE)
 
@@ -21,9 +23,16 @@ VM_CPUS        = VM_CPUS.to_i
 VM_BOX         = ENV['VM_BOX'] || "generic/ubuntu2204"
 USERNAME       = ENV['VM_USER'] || "admin"
 PASSWORD       = ENV['VM_PASS'] || "admin"
+USERNAME_SH    = Shellwords.escape(USERNAME)
+PASSWORD_SH    = Shellwords.escape(PASSWORD)
+CREATE_USER    = ENV.fetch('VM_CREATE_USER', 'true').strip.downcase == 'true'
 BRIDGE_IF      = ENV['BRIDGE_IF'] || "eth0"
 
 Vagrant.configure("2") do |config|
+  # Give Vagrant more total boot time before it gives up waiting for SSH.
+  config.vm.boot_timeout = 300
+  config.ssh.connect_timeout = 30
+  
   config.vm.provider :libvirt do |lv|
     lv.driver = "kvm"
   end
@@ -46,25 +55,27 @@ Vagrant.configure("2") do |config|
         lv.cpu_mode = "host-passthrough"
       end
 
-      # Provision: create user + enable password SSH
-      node.vm.provision "shell", inline: <<-SHELL
-        set -e
-        echo "=== SSH provisioning for user #{USERNAME} ==="
-        if ! id "#{USERNAME}" >/dev/null 2>&1; then
-          sudo useradd -m -s /bin/bash "#{USERNAME}"
-        fi
-        sudo usermod -aG sudo "#{USERNAME}"
-        echo "#{USERNAME}:#{PASSWORD}" | sudo chpasswd
-        echo "#{USERNAME} ALL=(ALL) NOPASSWD:ALL" | sudo tee /etc/sudoers.d/#{USERNAME}
+      if CREATE_USER
+        # Provision: create a lab user with password SSH and sudo access
+        node.vm.provision "shell", inline: <<-SHELL
+          set -e
+          echo "=== SSH provisioning for user #{USERNAME} ==="
+          if ! id #{USERNAME_SH} >/dev/null 2>&1; then
+            sudo useradd -m -s /bin/bash #{USERNAME_SH}
+          fi
 
-        sudo sed -i '/^AllowUsers/d' /etc/ssh/sshd_config
-        sudo sed -i '/^DenyUsers/d' /etc/ssh/sshd_config
-        sudo sed -i 's/^#\\?PasswordAuthentication .*/PasswordAuthentication yes/' /etc/ssh/sshd_config
-        sudo sed -i 's/^#\\?PermitRootLogin .*/PermitRootLogin yes/' /etc/ssh/sshd_config
-        sudo sed -i 's/^#\\?PubkeyAuthentication .*/PubkeyAuthentication yes/' /etc/ssh/sshd_config
+          sudo usermod -aG sudo #{USERNAME_SH}
+          printf '%s:%s\n' #{USERNAME_SH} #{PASSWORD_SH} | sudo chpasswd
+          printf '%s ALL=(ALL) NOPASSWD:ALL\n' #{USERNAME_SH} | sudo tee /etc/sudoers.d/#{USERNAME_SH} >/dev/null
 
-        sudo systemctl restart ssh || sudo systemctl restart sshd
-      SHELL
+          sudo sed -i '/^AllowUsers/d' /etc/ssh/sshd_config
+          sudo sed -i '/^DenyUsers/d' /etc/ssh/sshd_config
+          sudo sed -i 's/^#\\?PasswordAuthentication .*/PasswordAuthentication yes/' /etc/ssh/sshd_config
+          sudo sed -i 's/^#\\?PubkeyAuthentication .*/PubkeyAuthentication yes/' /etc/ssh/sshd_config
+
+          sudo systemctl restart ssh || sudo systemctl restart sshd
+        SHELL
+      end
     end
   end
 end

--- a/vagrant/template.env
+++ b/vagrant/template.env
@@ -13,10 +13,19 @@ VM_MEMORY=2048
 # VM_CPUS: Number of CPUs allocated to each VM
 VM_CPUS=2
 
-# VM_USER: Username to create in each VM
+# VM_CREATE_USER:
+# true  = manage VM_USER in the guest, set VM_PASS, grant sudo, and enable password SSH
+# false = skip user/SSH provisioning; on a fresh VM, the base box stays unchanged
+# Modes:
+# 1. Original Vagrant user:        VM_CREATE_USER=false
+# 2. Vagrant user + SSH password:  VM_CREATE_USER=true  and VM_USER=vagrant  VM_PASS=vagrant
+# 3. Fully new lab user:           VM_CREATE_USER=true  and VM_USER=admin    VM_PASS=admin
+VM_CREATE_USER=true
+
+# VM_USER: Username to manage in each VM
 VM_USER=admin
 
-# VM_PASS: Password for the created user
+# VM_PASS: Password applied to VM_USER when VM_CREATE_USER=true
 VM_PASS=admin
 
 # BRIDGE_IF: Host network interface to bridge for VM LAN access (e.g., eno1)


### PR DESCRIPTION
- Added `VM_CREATE_USER` option to control user creation and SSH provisioning in Vagrant setup.
- Hardened provisioning script to escape shell values for security.
- Increased SSH startup tolerance with extended boot and connect timeouts.
- Updated Vagrant lab guide to clarify user management modes and VM recreation instructions.
- Expanded README with detailed network design and usage scenarios.